### PR TITLE
add reusable nix modules for dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ### Description
 These are my dotfiles. I am using `stow` to manage them, so you could call them `stowfiles` lmao.
 
+This repo also exports reusable Home Manager and NixOS modules from `flake.nix`, so the same configs can be imported from any Nix flake.
+
 Much inspiration from https://github.com/ChristianChiarulli/Machfiles.
 
 ### Installing
@@ -35,6 +37,90 @@ The deploy script just does `stow */` and the `extra.gitconfig` to your .gitconf
 
 ### Usage
 `tmux`, `vim`, `nvim` and other applications use this repository's config.
+
+### Nix flakes
+
+You can import the exported Home Manager modules directly from another flake:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+    dotfiles.url = "github:crpier/dotfiles";
+  };
+
+  outputs = { nixpkgs, home-manager, dotfiles, ... }: {
+    nixosConfigurations.my-host = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        home-manager.nixosModules.home-manager
+        {
+          home-manager.users.crpier = {
+            imports = [ dotfiles.homeManagerModules.default ];
+            crpier.dotfiles.enableAll = true;
+            crpier.dotfiles.installPackages = true;
+          };
+        }
+      ];
+    };
+  };
+}
+```
+
+You can also enable individual modules instead of the full set:
+
+```nix
+{
+  imports = [ dotfiles.homeManagerModules.default ];
+
+  crpier.dotfiles.fish.enable = true;
+  crpier.dotfiles.kitty.enable = true;
+  crpier.dotfiles.tmux.enable = true;
+}
+```
+
+Or you can use the exported NixOS wrapper module and configure users from your system config:
+
+```nix
+{
+  inputs.dotfiles.url = "github:crpier/dotfiles";
+
+  outputs = { nixpkgs, dotfiles, ... }: {
+    nixosConfigurations.my-host = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        dotfiles.nixosModules.default
+        {
+          crpier.dotfiles.users.crpier = {
+            enable = true;
+            enableAll = true;
+            installPackages = true;
+          };
+        }
+      ];
+    };
+  };
+}
+```
+
+If you only want a subset for one user:
+
+```nix
+{
+  crpier.dotfiles.users.crpier = {
+    enable = true;
+    enableAll = false;
+    installPackages = true;
+    modules.fish = true;
+    modules.kitty = true;
+    modules.tmux = true;
+  };
+}
+```
+
+Package bundles are optional and install the common tools each config expects. The wrapper enables them by default, while direct Home Manager usage can opt in with `crpier.dotfiles.installPackages = true;`.
 
 This is also nicely extensible. Many dotfiles here source other files from `~/.config/local_configs/`, so you can put more source controlled stuff next to you source controlled stuff. 
 For example, you can fork this public repo, on both your work and personal laptops, and then extend it with private dotfiles repos. All that these other repos need is to keep config files in the `~/.config/local_configs/` folder.

--- a/fish/.config/fish/config.fish
+++ b/fish/.config/fish/config.fish
@@ -29,7 +29,7 @@ set -U fish_prompt_pwd_dir_length 100
 set -U VIRTUAL_ENV_DISABLE_PROMPT yes
 
 # General settings
-set -gx PATH ~/.local/bin ~/.cargo/bin /home/crpier/.opencode/bin/ ~/.bun/bin $PATH
+set -gx PATH ~/.local/bin ~/.cargo/bin "$HOME/.opencode/bin" ~/.bun/bin $PATH
 set -gx EDITOR nvim
 set -gx PYTHONPATH .
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,45 @@
+{
+  "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1774007980,
+        "narHash": "sha256-FOnZjElEI8pqqCvB6K/1JRHTE8o4rer8driivTpq2uo=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "9670de2921812bc4e0452f6e3efd8c859696c183",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773821835,
+        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "Reusable Home Manager and NixOS modules from crpier's dotfiles";
+
+  inputs.home-manager.url = "github:nix-community/home-manager";
+
+  outputs = { self, home-manager, ... }: {
+    homeManagerModules = {
+      default = import ./modules/home-manager;
+      fish = import ./modules/home-manager/fish.nix;
+      gitconfig = import ./modules/home-manager/gitconfig.nix;
+      kitty = import ./modules/home-manager/kitty.nix;
+      lazygit = import ./modules/home-manager/lazygit.nix;
+      opencode = import ./modules/home-manager/opencode.nix;
+      ranger = import ./modules/home-manager/ranger.nix;
+      tmux = import ./modules/home-manager/tmux.nix;
+    };
+
+    nixosModules = {
+      default = import ./modules/nixos { inherit self home-manager; };
+      dotfiles = import ./modules/nixos { inherit self home-manager; };
+    };
+  };
+}

--- a/kitty/.config/kitty/kitty.conf
+++ b/kitty/.config/kitty/kitty.conf
@@ -18,8 +18,8 @@ tab_bar_min_tabs 1
 active_tab_font_style   bold-italic
 inactive_tab_font_style bold
 background_opacity 1
-shell /usr/bin/fish
-editor /home/crpier/.local/bin/nvim
+shell fish
+editor nvim
 allow_remote_control yes
 macos_option_as_alt no
 kitty_modifications enabled
@@ -102,7 +102,7 @@ map kitty_mod+m toggle_marker
 map kitty_mod+c remote_control set-colors --all ~/.config/kitty/current-theme.conf
 
 # My machine-specific config
-include ~/.config/local_configs/kitty.conf
+globinclude ~/.config/local_configs/kitty.conf
 
 # Theme: Catppuccin-Macchiato
 include current-theme.conf

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -1,0 +1,33 @@
+{ config, lib, ... }:
+{
+  imports = [
+    ./fish.nix
+    ./gitconfig.nix
+    ./kitty.nix
+    ./lazygit.nix
+    ./opencode.nix
+    ./ranger.nix
+    ./tmux.nix
+  ];
+
+  options.crpier.dotfiles.enableAll = lib.mkEnableOption "all crpier dotfiles modules";
+  options.crpier.dotfiles.installPackages = lib.mkEnableOption "package bundles for all crpier dotfiles modules";
+
+  config = lib.mkIf config.crpier.dotfiles.enableAll {
+    crpier.dotfiles.fish.enable = lib.mkDefault true;
+    crpier.dotfiles.gitconfig.enable = lib.mkDefault true;
+    crpier.dotfiles.kitty.enable = lib.mkDefault true;
+    crpier.dotfiles.lazygit.enable = lib.mkDefault true;
+    crpier.dotfiles.opencode.enable = lib.mkDefault true;
+    crpier.dotfiles.ranger.enable = lib.mkDefault true;
+    crpier.dotfiles.tmux.enable = lib.mkDefault true;
+
+    crpier.dotfiles.fish.installPackages = lib.mkDefault config.crpier.dotfiles.installPackages;
+    crpier.dotfiles.gitconfig.installPackages = lib.mkDefault config.crpier.dotfiles.installPackages;
+    crpier.dotfiles.kitty.installPackages = lib.mkDefault config.crpier.dotfiles.installPackages;
+    crpier.dotfiles.lazygit.installPackages = lib.mkDefault config.crpier.dotfiles.installPackages;
+    crpier.dotfiles.opencode.installPackages = lib.mkDefault config.crpier.dotfiles.installPackages;
+    crpier.dotfiles.ranger.installPackages = lib.mkDefault config.crpier.dotfiles.installPackages;
+    crpier.dotfiles.tmux.installPackages = lib.mkDefault config.crpier.dotfiles.installPackages;
+  };
+}

--- a/modules/home-manager/fish.nix
+++ b/modules/home-manager/fish.nix
@@ -30,7 +30,122 @@ in
       ++ cfg.extraPackages
     );
 
-    xdg.configFile."fish/config.fish".source = ../../fish/.config/fish/config.fish;
+    programs.fish = {
+      enable = true;
+      shellAliases = {
+        ks = "kitty +kitten ssh";
+        icat = "kitty +kitten icat";
+        n = "nvim";
+        rn = "uv run nvim";
+        nconfig = "nvim $HOME/.config/nvim/init.lua";
+        nlconfig = "nvim $HOME/.config/local_configs/nvim.lua";
+        fconfig = "nvim $HOME/.config/fish/config.fish";
+        flconfig = "nvim $HOME/.config/local_configs/config.fish";
+        kconfig = "nvim $HOME/.config/kitty/kitty.conf";
+        klconfig = "nvim $HOME/.config/local_configs/kitty.conf";
+        gconfig = "nvim $HOME/.gitconfig";
+        glconfig = "nvim $HOME/.config/extra.gitconfig";
+        b = "bat";
+        rsource = "source $HOME/.config/fish/config.fish";
+        rpython = ''uv run --with rich python -i -c "from rich import inspect; from rich import pretty; pretty.install()"'';
+        k = "kubectl";
+        g = "git";
+        gs = "git status";
+        ga = "git add .";
+        gc = "git commit -m";
+        gcl = "git clone";
+        gco = "git checkout";
+        ge = "git clean -fd";
+        gd = "git diff";
+        gac = "git add . && git commit -m";
+        gu = "git pull";
+        gpom = "git pull origin master";
+        gp = "git push";
+        gr = "git reset HEAD --hard";
+        glo = "git log";
+        gl = "git lg";
+        gl2 = "git lg2";
+        gw = "git worktree";
+        gsf = "git fetch origin 'refs/heads/*:refs/heads/*'";
+        lg = "lazygit";
+        e = "eza";
+        ea = "eza -a";
+        el = "eza -l";
+        ela = "eza -la";
+        et = "eza -aT --git-ignore -I '.git|.venv|node_modules|.solid|__pycache__'";
+        stats = "echo $status";
+        rmf = "rm -rf";
+        opencode = "env OPENCODE_EXPERIMENTAL_PLAN_MODE=1 opencode";
+      };
+      shellAbbrs = {
+        ur = "uv run";
+      };
+      functions = {
+        fish_mode_prompt = "";
+        fish_prompt = ''
+          set -l last_status $status
+          echo -e ''
+          set_color $fish_color_cwd
+          echo -n (prompt_pwd)
+          set_color normal
+          echo -n ' '
+          if set -q VIRTUAL_ENV
+              set_color $fish_color_escape
+              echo -n \((basename $VIRTUAL_ENV)\)
+              set_color normal
+          end
+          __terlar_git_prompt
+          echo
+          if not test $last_status -eq 0
+              set_color $fish_color_error
+          end
+          echo -n '➤ '
+          set_color normal
+        '';
+        no = ''
+          set last_file (
+              nvim --headless -u NONE \
+                  +'lua io.write(vim.v.oldfiles[1] or "")' +q 2>/dev/null
+          )
+
+          if test -n "$last_file"; and test -f "$last_file"
+              nvim $last_file $argv
+          else
+              nvim $argv
+          end
+        '';
+        gacp = ''
+          set message $argv[1]
+          git add .
+          git commit -m "$message"
+          git push
+        '';
+        mkcd = ''
+          set folder $argv[1]
+          set args $argv[2..]
+          mkdir $args $folder
+          cd $folder
+        '';
+        last_history_item = ''
+          echo $history[1]
+        '';
+      };
+      interactiveShellInit = ''
+        set -g fish_prompt_pwd_dir_length 100
+        set -gx VIRTUAL_ENV_DISABLE_PROMPT yes
+
+        set -gx PATH ~/.local/bin ~/.cargo/bin "$HOME/.opencode/bin" ~/.bun/bin $PATH
+        set -gx EDITOR nvim
+        set -gx PYTHONPATH .
+
+        abbr -a !! --position anywhere --function last_history_item
+
+        if test -f ~/.config/local_configs/config.fish
+            source ~/.config/local_configs/config.fish
+        end
+      '';
+    };
+
     xdg.configFile."fish/completions" = {
       source = ../../fish/.config/fish/completions;
       recursive = true;

--- a/modules/home-manager/fish.nix
+++ b/modules/home-manager/fish.nix
@@ -1,0 +1,48 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.crpier.dotfiles.fish;
+in
+{
+  options.crpier.dotfiles.fish = {
+    enable = lib.mkEnableOption "crpier fish dotfiles";
+    installPackages = lib.mkEnableOption "packages used by crpier fish dotfiles";
+    extraPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = "Extra packages to install with the fish dotfiles bundle.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.optionals cfg.installPackages (
+      with pkgs;
+      [
+        fish
+        neovim
+        uv
+        bat
+        kubectl
+        git
+        lazygit
+        eza
+        kitty
+      ]
+      ++ cfg.extraPackages
+    );
+
+    xdg.configFile."fish/config.fish".source = ../../fish/.config/fish/config.fish;
+    xdg.configFile."fish/completions" = {
+      source = ../../fish/.config/fish/completions;
+      recursive = true;
+    };
+    xdg.configFile."fish/functions" = {
+      source = ../../fish/.config/fish/functions;
+      recursive = true;
+    };
+    xdg.configFile."fish/themes" = {
+      source = ../../fish/.config/fish/themes;
+      recursive = true;
+    };
+    xdg.configFile."local_configs/config.fish".text = lib.mkDefault "";
+  };
+}

--- a/modules/home-manager/gitconfig.nix
+++ b/modules/home-manager/gitconfig.nix
@@ -1,0 +1,35 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.crpier.dotfiles.gitconfig;
+in
+{
+  options.crpier.dotfiles.gitconfig = {
+    enable = lib.mkEnableOption "crpier gitconfig extras";
+    installPackages = lib.mkEnableOption "packages used by crpier gitconfig";
+    extraPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = "Extra packages to install with the gitconfig bundle.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.optionals cfg.installPackages (
+      with pkgs;
+      [
+        git
+        delta
+      ]
+      ++ cfg.extraPackages
+    );
+
+    programs.git.enable = lib.mkDefault true;
+    programs.git.includes = lib.mkAfter [
+      { path = "${config.xdg.configHome}/extra.gitconfig"; }
+    ];
+
+    xdg.configFile."extra.gitconfig".source = ../../gitconfig/.config/extra.gitconfig;
+    xdg.configFile."delta/catpuccin.gitconfig".text = lib.mkDefault "";
+    xdg.configFile."local_configs/gitconfig".text = lib.mkDefault "";
+  };
+}

--- a/modules/home-manager/gitconfig.nix
+++ b/modules/home-manager/gitconfig.nix
@@ -23,12 +23,34 @@ in
       ++ cfg.extraPackages
     );
 
-    programs.git.enable = lib.mkDefault true;
-    programs.git.includes = lib.mkAfter [
-      { path = "${config.xdg.configHome}/extra.gitconfig"; }
-    ];
+    programs.git = {
+      enable = lib.mkDefault true;
+      aliases = {
+        files = "!git diff --name-only $(git merge-base HEAD $(git rev-parse --abbrev-ref origin/HEAD))";
+        stat = "!git diff --stat $(git merge-base HEAD $(git rev-parse --abbrev-ref origin/HEAD))";
+      };
+      includes = lib.mkAfter [
+        { path = "${config.xdg.configHome}/delta/catpuccin.gitconfig"; }
+        { path = "${config.xdg.configHome}/local_configs/gitconfig"; }
+      ];
+      extraConfig = {
+        pull.rebase = false;
+        push.default = "current";
+        init.defaultBranch = "main";
+        core = {
+          pager = "delta";
+          editor = "nvim";
+        };
+        delta = {
+          line-numbers = true;
+          features = "catppuccin-macchiato";
+        };
+        merge.conflictstyle = "diff3";
+        diff.colorMoved = "default";
+        interactive.diffFilter = "delta --color-only";
+      };
+    };
 
-    xdg.configFile."extra.gitconfig".source = ../../gitconfig/.config/extra.gitconfig;
     xdg.configFile."delta/catpuccin.gitconfig".text = lib.mkDefault "";
     xdg.configFile."local_configs/gitconfig".text = lib.mkDefault "";
   };

--- a/modules/home-manager/kitty.nix
+++ b/modules/home-manager/kitty.nix
@@ -1,0 +1,33 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.crpier.dotfiles.kitty;
+in
+{
+  options.crpier.dotfiles.kitty = {
+    enable = lib.mkEnableOption "crpier kitty dotfiles";
+    installPackages = lib.mkEnableOption "packages used by crpier kitty dotfiles";
+    extraPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = "Extra packages to install with the kitty bundle.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.optionals cfg.installPackages (
+      with pkgs;
+      [
+        kitty
+        neovim
+        fish
+      ]
+      ++ cfg.extraPackages
+    );
+
+    xdg.configFile."kitty" = {
+      source = ../../kitty/.config/kitty;
+      recursive = true;
+    };
+    xdg.configFile."local_configs/kitty.conf".text = lib.mkDefault "";
+  };
+}

--- a/modules/home-manager/lazygit.nix
+++ b/modules/home-manager/lazygit.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.crpier.dotfiles.lazygit;
+in
+{
+  options.crpier.dotfiles.lazygit = {
+    enable = lib.mkEnableOption "crpier lazygit dotfiles";
+    installPackages = lib.mkEnableOption "packages used by crpier lazygit dotfiles";
+    extraPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = "Extra packages to install with the lazygit bundle.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.optionals cfg.installPackages (
+      with pkgs;
+      [
+        lazygit
+        git
+      ]
+      ++ cfg.extraPackages
+    );
+
+    xdg.configFile."lazygit" = {
+      source = ../../lazygit/.config/lazygit;
+      recursive = true;
+    };
+  };
+}

--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -1,0 +1,24 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.crpier.dotfiles.opencode;
+in
+{
+  options.crpier.dotfiles.opencode = {
+    enable = lib.mkEnableOption "crpier opencode dotfiles";
+    installPackages = lib.mkEnableOption "packages used by crpier opencode dotfiles";
+    extraPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = "Extra packages to install with the opencode bundle.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.optionals cfg.installPackages cfg.extraPackages;
+
+    xdg.configFile."opencode" = {
+      source = ../../opencode/.config/opencode;
+      recursive = true;
+    };
+  };
+}

--- a/modules/home-manager/ranger.nix
+++ b/modules/home-manager/ranger.nix
@@ -1,0 +1,33 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.crpier.dotfiles.ranger;
+in
+{
+  options.crpier.dotfiles.ranger = {
+    enable = lib.mkEnableOption "crpier ranger dotfiles";
+    installPackages = lib.mkEnableOption "packages used by crpier ranger dotfiles";
+    extraPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = "Extra packages to install with the ranger bundle.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.optionals cfg.installPackages (
+      with pkgs;
+      [
+        ranger
+        atool
+        xsel
+        fzf
+      ]
+      ++ cfg.extraPackages
+    );
+
+    xdg.configFile."ranger" = {
+      source = ../../ranger/.config/ranger;
+      recursive = true;
+    };
+  };
+}

--- a/modules/home-manager/tmux.nix
+++ b/modules/home-manager/tmux.nix
@@ -22,7 +22,11 @@ in
       ++ cfg.extraPackages
     );
 
-    home.file.".tmux.conf".source = ../../tmux/.tmux.conf;
+    programs.tmux = {
+      enable = true;
+      extraConfig = builtins.readFile ../../tmux/.tmux.conf;
+    };
+
     xdg.configFile."local_configs/.tmux.conf".text = lib.mkDefault "";
   };
 }

--- a/modules/home-manager/tmux.nix
+++ b/modules/home-manager/tmux.nix
@@ -1,0 +1,28 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.crpier.dotfiles.tmux;
+in
+{
+  options.crpier.dotfiles.tmux = {
+    enable = lib.mkEnableOption "crpier tmux dotfiles";
+    installPackages = lib.mkEnableOption "packages used by crpier tmux dotfiles";
+    extraPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = "Extra packages to install with the tmux bundle.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.optionals cfg.installPackages (
+      with pkgs;
+      [
+        tmux
+      ]
+      ++ cfg.extraPackages
+    );
+
+    home.file.".tmux.conf".source = ../../tmux/.tmux.conf;
+    xdg.configFile."local_configs/.tmux.conf".text = lib.mkDefault "";
+  };
+}

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1,0 +1,59 @@
+{ self, home-manager }:
+{ config, lib, ... }:
+let
+  userModule = { name, ... }: {
+    options = {
+      enable = lib.mkEnableOption "crpier dotfiles for ${name}";
+      enableAll = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Enable the full exported dotfiles set for this user.";
+      };
+      installPackages = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Install package bundles for enabled dotfiles modules for this user.";
+      };
+      modules = {
+        fish = lib.mkEnableOption "fish dotfiles for ${name}";
+        gitconfig = lib.mkEnableOption "gitconfig dotfiles for ${name}";
+        kitty = lib.mkEnableOption "kitty dotfiles for ${name}";
+        lazygit = lib.mkEnableOption "lazygit dotfiles for ${name}";
+        opencode = lib.mkEnableOption "opencode dotfiles for ${name}";
+        ranger = lib.mkEnableOption "ranger dotfiles for ${name}";
+        tmux = lib.mkEnableOption "tmux dotfiles for ${name}";
+      };
+    };
+  };
+
+  enabledUsers = lib.filterAttrs (_: userCfg: userCfg.enable) config.crpier.dotfiles.users;
+in
+{
+  imports = [ home-manager.nixosModules.home-manager ];
+
+  options.crpier.dotfiles.users = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.submodule userModule);
+    default = { };
+    description = "Users that should receive the exported crpier dotfiles Home Manager modules.";
+  };
+
+  config = lib.mkIf (enabledUsers != { }) {
+    home-manager.useGlobalPkgs = lib.mkDefault true;
+    home-manager.useUserPackages = lib.mkDefault true;
+
+    home-manager.users = lib.mapAttrs (_: userCfg: {
+      imports = [ self.homeManagerModules.default ];
+
+      crpier.dotfiles.enableAll = userCfg.enableAll;
+      crpier.dotfiles.installPackages = userCfg.installPackages;
+
+      crpier.dotfiles.fish.enable = lib.mkDefault userCfg.modules.fish;
+      crpier.dotfiles.gitconfig.enable = lib.mkDefault userCfg.modules.gitconfig;
+      crpier.dotfiles.kitty.enable = lib.mkDefault userCfg.modules.kitty;
+      crpier.dotfiles.lazygit.enable = lib.mkDefault userCfg.modules.lazygit;
+      crpier.dotfiles.opencode.enable = lib.mkDefault userCfg.modules.opencode;
+      crpier.dotfiles.ranger.enable = lib.mkDefault userCfg.modules.ranger;
+      crpier.dotfiles.tmux.enable = lib.mkDefault userCfg.modules.tmux;
+    }) enabledUsers;
+  };
+}

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -134,6 +134,6 @@ bind-key -T copy-mode-vi y send -X copy-selection-and-cancel
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 TMUX_FZF_LAUNCH_KEY="f"
 # bind-key "s" run-shell -b "~/.tmux/plugins/tmux-fzf/scripts/session.sh attach"
-run '~/.tmux/plugins/tpm/tpm'
+if-shell 'test -f $HOME/.tmux/plugins/tpm/tpm' 'run "$HOME/.tmux/plugins/tpm/tpm"'
 
 if-shell 'test -f $HOME/.config/local_configs/.tmux.conf' 'source-file $HOME/.config/local_configs/.tmux.conf'


### PR DESCRIPTION
## Summary
- export the dotfiles repo as reusable Home Manager and NixOS flake modules with optional package bundles
- make the configs more portable by removing hardcoded user paths and guarding optional local extensions
- start converting core modules to native Home Manager options for tmux, git, and fish